### PR TITLE
Add C header files for server programming

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
     pre:
         - sudo service postgresql stop && sudo apt-get purge -y postgresql* && sudo rm -Rvf /etc/postgresql* /var/lib/postgresql
         - sudo userdel -r postgres
-        - sudo sudo apt-get update && sudo apt-get install postgresql-9.6 postgresql-contrib-9.6 postgresql-plpython-9.6
+        - sudo sudo apt-get update && sudo apt-get install postgresql-9.6 postgresql-contrib-9.6 postgresql-plpython-9.6 postgresql-server-dev-9.6
         - sudo service postgresql start
 database:
     override:


### PR DESCRIPTION
Server headers are necessary to compile MADlib against Postgresql.